### PR TITLE
Fixing Unhandled Exception setState()

### DIFF
--- a/lib/src/chiclet_animated_button.dart
+++ b/lib/src/chiclet_animated_button.dart
@@ -94,7 +94,6 @@ class ChicletAnimatedButton extends StatefulWidget {
 class _ChicletAnimatedButtonState extends State<ChicletAnimatedButton>
     with SingleTickerProviderStateMixin {
   late bool _isPressed = widget.isPressed;
-  static const Duration duration = Duration(milliseconds: 80);
 
   @override
   Widget build(BuildContext context) {
@@ -127,15 +126,9 @@ class _ChicletAnimatedButtonState extends State<ChicletAnimatedButton>
 
   Future<void> _handleButtonPress() async {
     setState(() {
-      _isPressed = true;
       if (widget.onPressed != null) {
         widget.onPressed!();
       }
-    });
-    await Future.delayed(duration, () {
-      setState(() {
-        _isPressed = false;
-      });
     });
   }
 

--- a/lib/src/chiclet_outlined_animated_button.dart
+++ b/lib/src/chiclet_outlined_animated_button.dart
@@ -109,7 +109,6 @@ class _ChicletOutlinedAnimatedButtonState
     extends State<ChicletOutlinedAnimatedButton>
     with SingleTickerProviderStateMixin {
   late bool _isPressed = widget.isPressed;
-  static const Duration duration = Duration(milliseconds: 80);
 
   @override
   Widget build(BuildContext context) {
@@ -145,15 +144,9 @@ class _ChicletOutlinedAnimatedButtonState
 
   Future<void> _handleButtonPress() async {
     setState(() {
-      _isPressed = true;
       if (widget.onPressed != null) {
         widget.onPressed!();
       }
-    });
-    await Future.delayed(duration, () {
-      setState(() {
-        _isPressed = false;
-      });
     });
   }
 

--- a/lib/src/chiclet_segmented_button_segment.dart
+++ b/lib/src/chiclet_segmented_button_segment.dart
@@ -135,7 +135,6 @@ class ChicletButtonSegment<T> extends StatefulWidget {
 class _ChicletAnimatedButtonState<T> extends State<ChicletButtonSegment<T>>
     with SingleTickerProviderStateMixin {
   late bool _isPressed = widget.isPressed;
-  static const Duration duration = Duration(milliseconds: 80);
 
   @override
   Widget build(BuildContext context) {
@@ -168,15 +167,9 @@ class _ChicletAnimatedButtonState<T> extends State<ChicletButtonSegment<T>>
 
   Future<void> _handleButtonPress() async {
     setState(() {
-      _isPressed = true;
       if (widget.onPressed != null) {
         widget.onPressed!();
       }
-    });
-    await Future.delayed(duration, () {
-      setState(() {
-        _isPressed = false;
-      });
     });
   }
 


### PR DESCRIPTION
Remove delay from future method to remove error unhandled exception setState() while button pressed

Remove _isPressed = true because _isPressed = true is already handled by onTapDown 